### PR TITLE
fix crash with no embedded join message

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -186,15 +186,16 @@ local function perform_registrations()
                     }
                 end
             else
+                local last_login = get.send_last_login and replace(get.last_login_text, name, os.date(get.date, last_login)) or replace(get.join_text, name)
                 if not get.use_embeds_on_joins then
-                    data = {
-                        content = get.notification_prefix .. " " .. get.send_last_login and replace(get.last_login_text, name, os.date(get.date, last_login)) or replace(get.join_text, name)
+		    data = {
+                        content = get.notification_prefix .. " " .. last_login 
                     }
                 else
                     data = {
                         content = nil,
                         embeds = {{
-                            description = get.send_last_login and replace(get.last_login_text, name, os.date(get.date, last_login)) or replace(get.join_text, name),
+                            description = last_login,
                             color = get.join_color
                         }}
                     }


### PR DESCRIPTION
Logs of the crash

```
2024-02-04 22:54:37: ACTION[Main]: [doc] Wrote player data into /home/minetest/code/minetest/bin/../worlds/world/doc.mt.
2024-02-04 22:54:37: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod '??' in callback on_joinplayer(): ...in/../worlds/world/worldmods/ARACA/mt-dcwebhook/init.lua:191: attempt to concatenate field 'send_last_login' (a boolean value)
2024-02-04 22:54:37: ERROR[Main]: stack traceback:
2024-02-04 22:54:37: ERROR[Main]:       ...in/../worlds/world/worldmods/ARACA/mt-dcwebhook/init.lua:191: in function <...in/../worlds/world/worldmods/ARACA/mt-dcwebhook/init.lua:169>
2024-02-04 22:54:37: ERROR[Main]:       ...inetest/code/minetest/bin/../builtin/common/register.lua:26: in function <...inetest/code/minetest/bin/../builtin/common/register.lua:12>

```